### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,6 @@
 name: Test Theme
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/justin/carpeaqua-template/security/code-scanning/2](https://github.com/justin/carpeaqua-template/security/code-scanning/2)

To correct this problem, we should explicitly set the `permissions` key to limit the GitHub Actions runner’s token access. The safest approach is to set `permissions: contents: read` at the top level of the workflow (right after the `name` key), so that this restriction applies to all jobs in the workflow. This covers almost all CI scenarios where no write or administrative access is required. We do not need to make changes inside the jobs section unless individual jobs need broader access—which does not appear to be the case here.

**Modification summary:**  
- Edit the `.github/workflows/main.yml` file.
- Add the following block after the `name` field (and before the `on` field):  
  ```yaml
  permissions:
    contents: read
  ```
- No additional imports, definitions, or job-specific permission blocks are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
